### PR TITLE
Always reset execution result to match new result from retry

### DIFF
--- a/lib/rspec/retryable/example.rb
+++ b/lib/rspec/retryable/example.rb
@@ -28,6 +28,8 @@ module RSpec
         if @payload.retry
           # Replaced the final result by the retry result
           @payload.result = retry_example
+          # Update the execution result status to the new state
+          execution_result.status = @payload.state
         end
 
         # Notify reporter only if it's not handled by the handlers

--- a/lib/rspec/retryable/version.rb
+++ b/lib/rspec/retryable/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module Retryable
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Currently when the test example first enters `finish`, `record_finished` sets example's `execution_result.status`. But since retry was using a duplicated `example` object, it will not propagate the new result to original example. 

This PR sets the new state back to `execution_result.status` when retry was performed.