### PR TITLE
Set example execution result when retried; Add high level tests

### DIFF
--- a/lib/rspec/retryable/example.rb
+++ b/lib/rspec/retryable/example.rb
@@ -28,8 +28,6 @@ module RSpec
         if @payload.retry
           # Replaced the final result by the retry result
           @payload.result = retry_example
-          # Update the execution result status to the new state
-          execution_result.status = @payload.state
         end
 
         # Notify reporter only if it's not handled by the handlers
@@ -65,7 +63,16 @@ module RSpec
         # Use same reporter from example instead of the one passing in to behave like
         # a fresh new example.
 
-        new_example.run(instance, reporter)
+        result = new_example.run(instance, reporter)
+        # Update the execution result status to the new state from retry
+        execution_result.status = new_example.execution_result.status
+
+        if execution_result.status == :failed
+          # Sets exception when retry failed
+          execution_result.exception = new_example.execution_result.exception
+        end
+
+        result
       end
 
       def notify_reporter

--- a/lib/rspec/retryable/handlers.rb
+++ b/lib/rspec/retryable/handlers.rb
@@ -11,6 +11,10 @@ module RSpec
         @handlers << klass.new(*args, **kwargs)
       end
 
+      def reset!
+        @handlers.clear
+      end
+
       def invoke(payload)
         traverse(0, payload)
       end

--- a/lib/rspec/retryable/version.rb
+++ b/lib/rspec/retryable/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module Retryable
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/rspec/retryable_spec.rb
+++ b/spec/rspec/retryable_spec.rb
@@ -5,7 +5,97 @@ RSpec.describe RSpec::Retryable do
     expect(RSpec::Retryable::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(true).to eq(true)
+  describe ".bind" do
+    def capture_target_example(&block)
+      reporter = RSpec::Core::Reporter.new(RSpec::Core::Configuration.new)
+
+      target, result = nil, nil
+
+      listener = double("Listener")
+      allow(listener).to receive(:example_finished) do |notification|
+        target = notification.example
+      end
+
+      reporter.register_listener(listener, :example_finished)
+
+      result = RSpec.describe(&block).run(reporter)
+
+      [target, result]
+    end
+
+    context "when running example without retry" do
+      it "returns proper result" do
+        target, result = capture_target_example do
+          it { expect(1).to eq(1) }
+        end
+
+        expect(target).to be_a(RSpec::Core::Example)
+        expect(target.metadata).to have_key(:retryable)
+        expect(result).to eq(true)
+      end
+
+      context "when failed" do
+        it "returns proper result" do
+          target, result = capture_target_example do
+            it { expect(1).to eq(2) }
+          end
+
+          expect(target).to be_a(RSpec::Core::Example)
+          expect(target.metadata).to have_key(:retryable)
+          expect(target.exception).to be_a(RSpec::Expectations::ExpectationNotMetError)
+          expect(result).to eq(false)
+        end
+      end
+    end
+
+    context "when running example with a retry handler" do
+      before do
+        RSpec::Retryable.handlers.register(Class.new do
+          def self.retries=(value)
+            @retries = value
+          end
+
+          def self.retries
+            @retries ||= 0
+          end
+
+          def call(payload)
+            if self.class.retries.zero?
+              payload.retry = true
+            end
+
+            self.class.retries += 1
+          end
+        end)
+      end
+
+      it 'runs the test multiple times' do
+        target, result = capture_target_example do
+          it { expect(1).to eq(2) }
+        end
+
+        expect(target.metadata[:retryable].attempts).to eq(1)
+        expect(target.execution_result.status).to eq(:failed)
+        expect(target.exception).to be_a(RSpec::Expectations::ExpectationNotMetError)
+        expect(result).to eq(false)
+      end
+
+      context "when retry passed" do
+        it "returns proper result" do
+          results = [2, 1]
+
+          target, result = capture_target_example do
+            it '' do
+              expect(1).to eq(results.shift)
+            end
+          end
+
+          expect(target.metadata[:retryable].attempts).to eq(1)
+          expect(target.execution_result.status).to eq(:passed)
+          expect(target.exception).to be_nil
+          expect(result).to eq(true)
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rspec/retryable"
+require 'rspec/core/sandbox'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,4 +13,24 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.after { RSpec::Retryable.handlers.reset! }
+
+  # Sandboxing: https://github.com/rspec/rspec-core/blob/main/spec/support/sandboxing.rb
+  config.around do |ex|
+    RSpec::Core::Sandbox.sandboxed do |config|
+      # If there is an example-within-an-example, we want to make sure the inner example
+      # does not get a reference to the outer example (the real spec) if it calls
+      # something like `pending`
+      config.before(:context) { RSpec.current_example = nil }
+
+      config.color_mode = :off
+
+      orig_load_path = $LOAD_PATH.dup
+      ex.run
+      $LOAD_PATH.replace(orig_load_path)
+    end
+  end
 end
+
+RSpec::Retryable.bind


### PR DESCRIPTION
Previous attempt was using `payload.state` to update `execution_result.status` which is incorrect since payload.state can remain unchanged during processing handlers.

This PR sets the execution result from retried example inside `retry_example` method to ensure it was updated to by last retry result.