### PR TITLE
fix: fix missing shared example group frame when retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-retryable (0.3.0)
+    rspec-retryable (0.4.0)
       rspec-core (~> 3.0)
 
 GEM

--- a/lib/rspec/retryable/example.rb
+++ b/lib/rspec/retryable/example.rb
@@ -56,6 +56,10 @@ module RSpec
         @payload.notify = false
         # Duplicate the example for re-run
         new_example = duplicate_with(metadata)
+        # The shared_group_inclusion_backtrace was reserved from duplication, but we need to keep as-is for
+        # reporter/formatter to show the correct backtrace.
+        # https://github.com/rspec/rspec/blob/0ae9cc43163507458494e631ca8e473bf24cdb26/rspec-core/lib/rspec/core/metadata.rb#L341
+        new_example.metadata[:shared_group_inclusion_backtrace] = metadata[:shared_group_inclusion_backtrace]
         new_example.instance_variable_set(:@id, id)
         # Taken from https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/example_group.rb#L644-L646
         instance = new_example.example_group.new(new_example.inspect_output)

--- a/lib/rspec/retryable/version.rb
+++ b/lib/rspec/retryable/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module Retryable
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
The `shared_group_inclusion_backtrace` metadata was reserved from duplication, but we need to keep as-is for reporter/formatter to show the correct backtrace under shared examples.

Ref: https://github.com/rspec/rspec/blob/0ae9cc43163507458494e631ca8e473bf24cdb26/rspec-core/lib/rspec/core/metadata.rb#L341
